### PR TITLE
Fix for latest version of React Native

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Checkbox component for React native
 
 Install the component through npm using:
 
-```js
+```
 npm install react-native-checkbox --save
 ```
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@ Checkbox component for React native
 
 ##Installation:
 
-First you need to add `cb_disabled.png` and `cb_enabled.png` images from the repository as image assets inside your XCode project. Here is the link on how to do that https://facebook.github.io/react-native/docs/image.html#adding-static-resources-to-your-ios-app-using-images-xcassets
-
-Then you can install the component through npm using:
+Install the component through npm using:
 
 ```js
 npm install react-native-checkbox --save

--- a/checkbox.js
+++ b/checkbox.js
@@ -34,10 +34,10 @@ var CheckBox = React.createClass({
   },
 
   render() {
-    var source = require('image!cb_disabled');
+    var source = require('./cb_disabled.png');
 
     if(this.props.checked){
-      source = require('image!cb_enabled');
+      source = require('./cb_enabled.png');
     }
 
     var container = (


### PR DESCRIPTION
There's a new syntax for referencing static images now. It's actually better since it doesn't require people to add images in Xcode.

(I also made an incredibly anal fix to the markdown that doesn't even affect how GitHub renders it.)