### PR TITLE
Removed lineHeight from the lable style so text renders completely.

### DIFF
--- a/checkbox.js
+++ b/checkbox.js
@@ -88,8 +88,7 @@ var styles = StyleSheet.create({
   },
   label: {
     fontSize: 15,
-    lineHeight: 15,
-    color: 'grey',
+    color: 'grey'
   }
 });
 


### PR DESCRIPTION
Rendering is messed up when the lineHeight is specified, appears to not be needed.