### PR TITLE
Enhance labelStyle

### DIFF
--- a/checkbox.js
+++ b/checkbox.js
@@ -14,7 +14,7 @@ var {
 var CheckBox = React.createClass({
   propTypes: {
     label: PropTypes.string,
-    labelStyle: PropTypes.object,
+    labelStyle: PropTypes.oneOfType([PropTypes.object,PropTypes.number]),
     checked: PropTypes.bool,
     onChange: PropTypes.func
   },


### PR DESCRIPTION
Allow a PropType.number so a predefined style may be passed in as in:
```
const styles=StyleSheet.create({
  label: {
    flex:1,
    flexWrap:'nowrap',
    fontSize: 16,
    marginLeft: 5,
    marginRight: 5,
    marginTop:10,
    color: '#656565',
  },
})
...
  render(){
    return (   
         <CheckBox
              label='Customer?'
              labelStyle={styles.label}
              labelBefore={true}
              checked={prospect.isCustomer}
              onChange={checked=>this.props.editProspectColumn('isCustomer',checked)}
            />
...
```
