### PR TITLE
Fix type coersion on the checked property

### DIFF
--- a/checkbox.js
+++ b/checkbox.js
@@ -18,13 +18,13 @@ class CheckBox extends Component {
 
         this.state = {
             internalChecked: false
-        }
+        };
 
         this.onChange = this.onChange.bind(this);
     }
 
     onChange() {
-        if (this.props.checked && this.props.onChange) {
+        if (typeof this.props.checked == 'boolean' && this.props.onChange) {
             this.props.onChange(this.props.checked);
         } else {
             let internalChecked = this.state.internalChecked;
@@ -47,10 +47,12 @@ class CheckBox extends Component {
             </View>
         );
 
-        let source = this.state.internalChecked ? this.props.checkedImage : this.props.uncheckedImage;
+        let source;
 
-        if(this.props.checked) {
-            source = this.props.checked ? this.props.checkedImage : this.props.uncheckedImage;
+        if(typeof this.props.checked == 'boolean') {
+          source = this.props.checked ? this.props.checkedImage : this.props.uncheckedImage;
+        } else {
+          source = this.state.internalChecked ? this.props.checkedImage : this.props.uncheckedImage;
         }
 
 
@@ -82,9 +84,9 @@ class CheckBox extends Component {
             <TouchableHighlight onPress={this.onChange} underlayColor={this.props.underlayColor} style={styles.flexContainer}>
                 {container}
             </TouchableHighlight>
-        )
+        );
     }
-};
+}
 
 var styles = StyleSheet.create({
     container: {

--- a/checkbox.js
+++ b/checkbox.js
@@ -24,11 +24,14 @@ class CheckBox extends Component {
     }
 
     onChange() {
-        if (typeof this.props.checked == 'boolean' && this.props.onChange) {
+        if (this.props.onChange &&  typeof this.props.checked === 'boolean') {
             this.props.onChange(this.props.checked);
         } else {
             let internalChecked = this.state.internalChecked;
-            this.props.onChange(internalChecked);
+
+            if(this.props.onChange){
+              this.props.onChange(internalChecked);
+            }
             this.setState({
                 internalChecked: !internalChecked
             });
@@ -49,7 +52,7 @@ class CheckBox extends Component {
 
         let source;
 
-        if(typeof this.props.checked == 'boolean') {
+        if(typeof this.props.checked === 'boolean') {
           source = this.props.checked ? this.props.checkedImage : this.props.uncheckedImage;
         } else {
           source = this.state.internalChecked ? this.props.checkedImage : this.props.uncheckedImage;
@@ -110,6 +113,7 @@ var styles = StyleSheet.create({
 
 CheckBox.propTypes = {
     label: PropTypes.string,
+    labelBefore: PropTypes.bool,
     labelStyle: PropTypes.oneOfType([PropTypes.array,PropTypes.object,PropTypes.number]),
     labelLines: PropTypes.number,
     checkboxStyle: PropTypes.oneOfType([PropTypes.array,PropTypes.object,PropTypes.number]),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-checkbox",
-  "version": "1.0.17",
+  "version": "1.1.0",
   "description": "Checkbox component for React native",
   "main": "checkbox.js",
   "scripts": {


### PR DESCRIPTION
This changes the 
`if(this.props.checked)` ==>` (typeof this.props.checked == 'boolean')`

this will allow you to programatically set the checkbox to false without breaking