### PR TITLE
label container style from props if possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ import CheckBox from 'react-native-checkbox';
 - `labelBefore` : position the label before the checkbox (boolean). The default
 value is false
 - `labelStyle` : style object that will be applied to the label
+- `labelContainerStyle` : style object that will be applied to the label container
 - `checked` : initial checked value
 - `checkedImage`: checked image (e.g.: require('PATH_TO_IMAGE'))
 - `checkboxStyle` : style object that will be applied to the

--- a/checkbox.js
+++ b/checkbox.js
@@ -44,7 +44,7 @@ class CheckBox extends Component {
                 <Image
                 style={this.props.checkboxStyle || styles.checkbox}
                 source={source}/>
-                <View style={styles.labelContainer}>
+			<View style={this.props.labelContainerStyle || styles.labelContainer}>
                     <Text style={[styles.label, this.props.labelStyle]}>{this.props.label}</Text>
                 </View>
             </View>
@@ -62,7 +62,7 @@ class CheckBox extends Component {
         if (this.props.labelBefore) {
             container = (
                 <View style={this.props.containerStyle || [styles.container, styles.flexContainer]}>
-                    <View style={styles.labelContainer}>
+                    <View style={this.props.labelContainerStyle || styles.labelContainer}>
                         <Text numberOfLines={this.props.labelLines} style={[styles.label, this.props.labelStyle]}>{this.props.label}</Text>
                     </View>
                     <Image
@@ -76,7 +76,7 @@ class CheckBox extends Component {
                     <Image
                     style={[styles.checkbox, this.props.checkboxStyle]}
                     source={source}/>
-                    <View style={styles.labelContainer}>
+				<View style={this.props.labelContainerStyle || styles.labelContainer}>
                         <Text numberOfLines={this.props.labelLines} style={[styles.label, this.props.labelStyle]}>{this.props.label}</Text>
                     </View>
                 </View>


### PR DESCRIPTION
Sometimes you might need to style the labelContainer. Mostly the left margin from checkbox should be fine due to accessibility, but one would like to get rid of the right margin, increase its value or keep the margin just on container.