### PR TITLE
fixes passing old (oppositte) checked state to the onChange callback

### DIFF
--- a/checkbox.js
+++ b/checkbox.js
@@ -28,12 +28,13 @@ class CheckBox extends Component {
             this.props.onChange(this.props.checked);
         } else {
             let internalChecked = this.state.internalChecked;
+            let newState = !internalChecked;
 
             if(this.props.onChange){
-              this.props.onChange(internalChecked);
+              this.props.onChange(newState);
             }
             this.setState({
-                internalChecked: !internalChecked
+                internalChecked: newState
             });
         }
     }


### PR DESCRIPTION
This should fix #59 