### PR TITLE
Use containerStyle prop, not non-existent style.flexContainer

### DIFF
--- a/checkbox.js
+++ b/checkbox.js
@@ -48,12 +48,13 @@ class CheckBox extends Component {
 
     render() {
         const containerStyle = this.props.containerStyle || styles.container;
+        const labelContainerStyle = this.props.labelContainerStyle || styles.labelContainer;
         let container = (
             <View style={containerStyle}>
                 <Image
                 style={this.props.checkboxStyle || styles.checkbox}
                 source={source}/>
-                <View style={styles.labelContainer}>
+                <View style={labelContainerStyle}>
                     <Text style={[styles.label, this.props.labelStyle]}>{this.props.label}</Text>
                 </View>
             </View>
@@ -72,7 +73,7 @@ class CheckBox extends Component {
             container = (
                 <View style={containerStyle}>
                     { (this.props.label ? (
-                      <View style={styles.labelContainer}>
+                      <View style={labelContainerStyle}>
                           <Text numberOfLines={this.props.labelLines} style={[styles.label, this.props.labelStyle]}>{this.props.label}</Text>
                       </View>
                     ) : <View></View>) }
@@ -88,7 +89,7 @@ class CheckBox extends Component {
                     style={[styles.checkbox, this.props.checkboxStyle]}
                     source={source}/>
                     { (this.props.label ? (
-                      <View style={styles.labelContainer}>
+                      <View style={labelContainerStyle}>
                           <Text numberOfLines={this.props.labelLines} style={[styles.label, this.props.labelStyle]}>{this.props.label}</Text>
                       </View>
                     ) : <View></View>) }
@@ -130,6 +131,7 @@ CheckBox.propTypes = {
     labelStyle: PropTypes.oneOfType([PropTypes.array,PropTypes.object,PropTypes.number]),
     labelLines: PropTypes.number,
     checkboxStyle: PropTypes.oneOfType([PropTypes.array,PropTypes.object,PropTypes.number]),
+    labelContainerStyle: PropTypes.oneOfType([PropTypes.array,PropTypes.object,PropTypes.number]),
     containerStyle: PropTypes.oneOfType([PropTypes.array,PropTypes.object,PropTypes.number]),
     checked: PropTypes.bool,
     checkedImage: PropTypes.number,

--- a/checkbox.js
+++ b/checkbox.js
@@ -47,8 +47,9 @@ class CheckBox extends Component {
     }
 
     render() {
+        const containerStyle = this.props.containerStyle || styles.container;
         let container = (
-            <View style={this.props.containerStyle || styles.container}>
+            <View style={containerStyle}>
                 <Image
                 style={this.props.checkboxStyle || styles.checkbox}
                 source={source}/>
@@ -69,7 +70,7 @@ class CheckBox extends Component {
 
         if (this.props.labelBefore) {
             container = (
-                <View style={this.props.containerStyle || [styles.container, styles.flexContainer]}>
+                <View style={containerStyle}>
                     { (this.props.label ? (
                       <View style={styles.labelContainer}>
                           <Text numberOfLines={this.props.labelLines} style={[styles.label, this.props.labelStyle]}>{this.props.label}</Text>
@@ -82,7 +83,7 @@ class CheckBox extends Component {
             );
         } else {
             container = (
-                <View style={[styles.container, this.props.containerStyle]}>
+                <View style={containerStyle}>
                     <Image
                     style={[styles.checkbox, this.props.checkboxStyle]}
                     source={source}/>
@@ -96,7 +97,7 @@ class CheckBox extends Component {
         }
 
         return (
-            <TouchableHighlight onPress={this.onChange} underlayColor={this.props.underlayColor} style={styles.flexContainer} disabled = {this.state.isDisabled}>
+            <TouchableHighlight onPress={this.onChange} underlayColor={this.props.underlayColor} style={containerStyle} disabled = {this.state.isDisabled}>
                 {container}
             </TouchableHighlight>
         );


### PR DESCRIPTION
There are repeated references to `flexContainer`, which does not appear to exist.
Additionally, the `containerStyle` prop doesn't appear to be used where I expected it.
Fixed for me. Not tested, other than exactly at my settings (ie. specifying a `containerStyle` of 
```
{
    flexDirection: 'row',
    alignItems: 'center',
    padding: 10,
  }
```