### PR TITLE
Correct: Warning: Failed prop type: Invalid prop  of type

### DIFF
--- a/checkbox.js
+++ b/checkbox.js
@@ -145,8 +145,8 @@ CheckBox.propTypes = {
     checkboxStyle: PropTypes.oneOfType([PropTypes.array,PropTypes.object,PropTypes.number]),
     containerStyle: PropTypes.oneOfType([PropTypes.array,PropTypes.object,PropTypes.number]),
     checked: PropTypes.bool,
-    checkedImage: PropTypes.number,
-    uncheckedImage: PropTypes.number,
+    checkedImage: PropTypes.object,
+    uncheckedImage: PropTypes.object,
     underlayColor: PropTypes.string,
     onChange: PropTypes.func,
     hitSlop: PropTypes.object


### PR DESCRIPTION
Correct the following:

Warning: Failed prop type: Invalid prop `checkedImage` of type `object` supplied to `CheckBox`, expected `number`. 