### PR TITLE
Fix componentWillMount warning on React Native 0.61.5+

### DIFF
--- a/checkbox.js
+++ b/checkbox.js
@@ -41,7 +41,8 @@ class CheckBox extends Component {
             });
         }
     }
-    componentWillMount() {
+    
+    componentDidMount() {
         this.setState(this.baseState)
     }
 


### PR DESCRIPTION
If you currently use the component on this version or higher (haven't checked the exact version where this became an issue), you will get a warning asking you to rename this function to componentDidMount. So I have done that, as well as tested that the component worked as usual, and so it has.